### PR TITLE
fix: upgrade phpunit + fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: php
 
 php:
-  - 5.5
-  - 5.6
+  - 7.1
+  - 7.2
+  - 7.3
 
 install:
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "guzzlehttp/guzzle": "^6.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0",
+        "phpunit/phpunit": "~7.0",
         "mockery/mockery": "^0.9.4"
     },
     "autoload": {

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -217,7 +217,7 @@ class ClientTest extends TestCase
     }
 
 
-    public function testRESTVerbsProvider()
+    public function RESTVerbsProvider()
     {
         return [
             ['get', null],
@@ -229,7 +229,7 @@ class ClientTest extends TestCase
     }
 
     /**
-     * @dataProvider testRESTVerbsProvider
+     * @dataProvider RESTVerbsProvider
      * @covers Classy\Client::get
      * @covers Classy\Client::post
      * @covers Classy\Client::delete
@@ -382,7 +382,7 @@ class ClientTest extends TestCase
             $this->fail('Exception expected');
         } catch (APIResponseException $e) {
             $this->assertEquals(400, $e->getCode());
-            $this->assertEquals('invalid_request', $e->getResponseData()->error);
+            $this->assertEquals('invalid_client', $e->getResponseData()->error);
             $this->assertEquals('application/json; charset=utf-8', $e->getResponseHeaders()['Content-Type'][0]);
         }
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,8 +6,10 @@ use Classy\Client;
 use Mockery;
 use PHPUnit_Framework_TestCase;
 
-class TestCase extends PHPUnit_Framework_TestCase
+class TestCase extends \PHPUnit\Framework\TestCase
 {
+    use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+
     /**
      * @var \Mockery\MockInterface
      */


### PR DESCRIPTION
I couldn't run the tests because the PHPunit version was so outdated.

This updates the version to the oldest supported version + fixes the test issues from the upgrade.